### PR TITLE
Update Gulpfile.babel.js

### DIFF
--- a/generators/app/templates/Gulpfile.babel.js
+++ b/generators/app/templates/Gulpfile.babel.js
@@ -18,7 +18,7 @@ export const development = series(
 		// Start browserSync
 		browsersync.init({
 			server: {
-				baseDir: ['src', 'dest'],
+				baseDir: ['dest'],
 				routes: {
 					'/node_modules': 'node_modules',
 				},


### PR DESCRIPTION
Having the src folder as a baseDir in the browsersync server option was serving the app with the uncompiled src js files instead of the compiled ones.